### PR TITLE
Update custom.scss for sticky search bar

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,3 +1,19 @@
+.main-header {
+  color: none;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: none;
+}
+
+.search {
+  color: none;
+  position: sticky;
+  top: 0;
+  z-index: 101;
+  background-color: none;
+}
+
 .side-bar {
   color: #EEE8FF;
   background-color: #EEE8FF;

--- a/index.md
+++ b/index.md
@@ -53,11 +53,11 @@ For any enquiries, or if you have any resources you would like to contribute to 
  </tr>
   <tr>
         <td><img src="https://bhfdsc.github.io/documentation/assets/images/laura_sherlock.png" alt="Laura Sherlock" style="width: 120px; height: 120px; object-fit: cover;"/></td>
-        <td>Laura Sherlock, Early Career Health Data Scientist</td>
+        <td>Laura Sherlock, Health Data Scientist</td>
  </tr>
     <tr>
         <td><img src="https://bhfdsc.github.io/documentation/assets/images/anna_stevenson.png" alt="Anna Stevenson" style="width: 120px; height: 120px; object-fit: cover;"/></td>
-        <td>Anna Stevenson, Early Career Health Data Scientist</td>
+        <td>Anna Stevenson, Health Data Scientist</td>
  </tr>
   <tr>
      <td><img src="https://bhfdsc.github.io/documentation/assets/images/zach_welshman.png" alt="Zach Welshman" style="width: 120px; height: 120px; object-fit: cover;"/></td>

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ For any enquiries, or if you have any resources you would like to contribute to 
         </tr>
   <tr>
      <td><img src="https://bhfdsc.github.io/documentation/assets/images/fionna_chalmers.png" alt="Fionna Chalmers" style="width: 120px; height: 120px; object-fit: cover;"/></td>
-        <td>Fionna Chalmers, Early Career Health Data Scientist</td>
+        <td>Fionna Chalmers, Health Data Scientist</td>
   </tr>
   <tr>
         <td><img src="https://bhfdsc.github.io/documentation/assets/images/jamie_farrell.png" alt="Jamie Farrell" style="width: 120px; height: 120px; object-fit: cover;"/></td>
@@ -53,7 +53,7 @@ For any enquiries, or if you have any resources you would like to contribute to 
  </tr>
   <tr>
         <td><img src="https://bhfdsc.github.io/documentation/assets/images/laura_sherlock.png" alt="Laura Sherlock" style="width: 120px; height: 120px; object-fit: cover;"/></td>
-        <td>Laura Sherlock, Health Data Scientist</td>
+        <td>Laura Sherlock, Early Career Health Data Scientist</td>
  </tr>
     <tr>
         <td><img src="https://bhfdsc.github.io/documentation/assets/images/anna_stevenson.png" alt="Anna Stevenson" style="width: 120px; height: 120px; object-fit: cover;"/></td>


### PR DESCRIPTION
Suggestion to add a sticky search bar to pin when scrolling on the documentation page. I have tested it here: https://bhfdschds.github.io/test-documentation/ to see what it looks like and if it's worth adding.

Also changed FC and AS role